### PR TITLE
fix(errors): Unknown auth errors use default code

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -52,7 +52,6 @@ class HttpErrorAuthUnknown extends HttpErrorBase {
   constructor (method, res, body, spec) {
     super(method, res, body, spec)
     this.message = 'Unable to authenticate, need: ' + res.headers.get('www-authenticate')
-    this.code = 'EAUTHUNOWN'
     Error.captureStackTrace(this, HttpErrorAuthUnknown)
   }
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -117,7 +117,7 @@ test('Unexpected www-authenticate error', t => {
       () => { throw new Error('Should not have succeeded!') },
       err => {
         t.match(err.body.error, /Pat-a-cake/ig, 'error body explains it')
-        t.equal(err.code, 'EAUTHUNOWN', 'got a special pokemon')
+        t.equal(err.code, 'E401', 'Unknown auth errors are generic 401s')
       }
     )
 })


### PR DESCRIPTION
If we can't identify the auth problem we should pass it through with default settings. (This was an error in the npm-profile implementation.)

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
