### PR TITLE
test(check-response): Added missing tests

### DIFF
--- a/test/check-response.js
+++ b/test/check-response.js
@@ -1,0 +1,67 @@
+const { Readable } = require('stream')
+const test = require('tap').test
+
+const config = require('../config.js')
+const checkResponse = require('../check-response.js')
+const errors = require('./errors.js')
+const silentLog = require('../silentlog.js')
+
+class Body extends Readable {
+  _read () { return '' }
+}
+class Headers {
+  has () {}
+  get () {}
+  raw () {}
+}
+const mockFetchRes = {
+  body: new Body(),
+  buffer: () => Promise.resolve(),
+  headers: new Headers(),
+  status: 200
+}
+
+test('any response error should be silent', t => {
+  const res = Object.assign({}, mockFetchRes, {
+    buffer: () => Promise.reject(new Error('ERR')),
+    status: 400
+  })
+  t.rejects(checkResponse('get', res, 'registry', Date.now(), { ignoreBody: true }), errors.HttpErrorGeneral)
+  t.done()
+})
+
+test('log x-fetch-attempts header value', t => {
+  const headers = new Headers()
+  headers.get = header => header === 'x-fetch-attempts' ? 3 : undefined
+  const res = Object.assign({}, mockFetchRes, {
+    headers,
+    status: 400
+  })
+  t.rejects(checkResponse('get', res, 'registry', Date.now(), config({
+    log: Object.assign({}, silentLog, {
+      http (header, msg) {
+        t.ok(msg.endsWith('attempt #3'), 'should log correct number of attempts')
+      }
+    })
+  })))
+  t.plan(2)
+})
+
+test('bad-formatted warning headers', t => {
+  const headers = new Headers()
+  headers.has = header => header === 'warning' ? 'foo' : undefined
+  headers.raw = () => ({
+    warning: ['100 - foo']
+  })
+  const res = Object.assign({}, mockFetchRes, {
+    headers
+  })
+  t.ok(checkResponse('get', res, 'registry', Date.now(), config({
+    log: Object.assign({}, silentLog, {
+      warn (header, msg) {
+        t.fail('should not log warnings')
+      }
+    })
+  })))
+  t.plan(1)
+})

--- a/test/index.js
+++ b/test/index.js
@@ -411,6 +411,23 @@ test('pickRegistry through opts.spec', t => {
   ))
 })
 
+test('log warning header info', t => {
+  tnock(t, OPTS.registry)
+    .get('/hello')
+    .reply(200, {hello: 'world'}, { Warning: '199 - "ENOTFOUND" "Wed, 21 Oct 2015 07:28:00 GMT"' })
+  const opts = OPTS.concat({
+    log: Object.assign({}, silentLog, {
+      warn (header, msg) {
+        t.equal(header, 'registry', 'expected warn log header')
+        t.equal(msg, `Using stale data from ${OPTS.registry} because the host is inaccessible -- are you offline?`, 'logged out at WARNING level')
+      }
+    })
+  })
+  t.plan(3)
+  return fetch('/hello', opts)
+    .then(res => t.equal(res.status, 200, 'got successful response'))
+})
+
 // TODO
 // * npm-session
 // * npm-in-ci


### PR DESCRIPTION
Added missing tests for `check-response.js` module in order to bump coverage.

- Added test coverage for warning header usage cases
- Added missing check for silenced errors when reading Responses
- Added check for correctly logging x-fetch-attempts header value