### PR TITLE
deps: make-fetch-happen@6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2644,9 +2644,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -3345,15 +3345,15 @@
       "dev": true
     },
     "make-fetch-happen": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-6.0.0.tgz",
-      "integrity": "sha512-0c4s/5ktozfRWPvii/Bang+an/YCPzkTRFSzEC6uBMTUp02ZskNGgNFm0rmmMLYlFN5OvW7HruLIDSS2fjQjOA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-6.0.1.tgz",
+      "integrity": "sha512-PAHjh/ohpW1lvc6eWHirvEoyQgRGa9g1Ugrddf0udiRdaVI/R4TMOqzGMEeM5tBzW6p4J+7kAQIKLgAxvLuT/A==",
       "requires": {
         "agentkeepalive": "^3.4.1",
         "cacache": "^13.0.1",
         "http-cache-semantics": "^3.8.1",
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
+        "https-proxy-agent": "^2.2.3",
         "lru-cache": "^5.1.1",
         "minipass": "^3.0.0",
         "minipass-collect": "^1.0.2",
@@ -3366,13 +3366,28 @@
       },
       "dependencies": {
         "ssri": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.0.1.tgz",
-          "integrity": "sha512-FfndBvkXL9AHyGLNzU3r9AvYIBBZ7gm+m+kd0p8cT3/v4OliMAyipZAhLVEv1Zi/k4QFq9CstRGVd9pW/zcHFQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+          "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
           "requires": {
             "figgy-pudding": "^3.5.1",
-            "minipass": "^3.0.0"
+            "minipass": "^3.1.1"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+              "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bluebird": "^3.5.1",
     "figgy-pudding": "^3.4.1",
     "lru-cache": "^5.1.1",
-    "make-fetch-happen": "^6.0.0",
+    "make-fetch-happen": "^6.0.1",
     "minipass": "^3.0.0",
     "minipass-fetch": "^1.1.2",
     "minipass-json-stream": "^1.0.1",


### PR DESCRIPTION
Updates package.json to use latest version of make-fetch-happen. v6.0.1 of make-fetch-happen updates version of dependency https-proxy-agent to address https://npmjs.com/advisories/1184

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
