### PR TITLE
fix: always bypass cache when ?write=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ Happy hacking!
 
 ### API
 
+#### Caching and `write=true` query strings
+
+Before performing any PUT or DELETE operation, npm clients first make a
+GET request to the registry resource being updated, which includes
+the query string `?write=true`.
+
+The semantics of this are, effectively, "I intend to write to this thing,
+and need to know the latest current value, so that my write can land
+cleanly".
+
+The public npm registry handles these `?write=true` requests by ensuring
+that the cache is re-validated before sending a response.  In order to
+maintain the same behavior on the client, and not get tripped up by an
+overeager local cache when we intend to write data to the registry, any
+request that comes through `npm-registry-fetch` that contains `write=true`
+in the query string will forcibly set the `prefer-online` option to `true`,
+and set both `prefer-offline` and `offline` to false, so that any local
+cached value will be revalidated.
+
 #### <a name="fetch"></a> `> fetch(url, [opts]) -> Promise<Response>`
 
 Performs a request to a given URL.
@@ -397,6 +416,9 @@ Force offline mode: no network requests will be done during install. To allow
 This option is only really useful if you're also using
 [`opts.cache`](#opts-cache).
 
+This option is set to `true` when the request includes `write=true` in the
+query string.
+
 ##### <a name="opts-otp"></a> `opts.otp`
 
 * Type: Number | String
@@ -408,7 +430,7 @@ account.
 
 ##### <a name="opts-password"></a> `opts.password`
 
-* Alias: _password
+* Alias: `_password`
 * Type: String
 * Default: null
 
@@ -438,6 +460,9 @@ will be requested from the server. To force full offline mode, use
 This option is generally only useful if you're also using
 [`opts.cache`](#opts-cache).
 
+This option is set to `false` when the request includes `write=true` in the
+query string.
+
 ##### <a name="opts-prefer-online"></a> `opts.prefer-online`
 
 * Type: Boolean
@@ -449,6 +474,8 @@ for updates immediately even for fresh package data.
 This option is generally only useful if you're also using
 [`opts.cache`](#opts-cache).
 
+This option is set to `true` when the request includes `write=true` in the
+query string.
 
 ##### <a name="opts-project-scope"></a> `opts.project-scope`
 
@@ -612,4 +639,4 @@ See also [`opts.password`](#opts-password)
 * Default: null
 
 ** DEPRECATED ** This is a legacy authentication token supported only for
-*compatibility. Please use [`opts.token`](#opts-token) instead.
+compatibility. Please use [`opts.token`](#opts-token) instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -465,6 +465,12 @@
         }
       }
     },
+    "caller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
+      "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3955,7 +3961,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -4681,6 +4687,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "require-inject": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/require-inject/-/require-inject-1.4.4.tgz",
+      "integrity": "sha512-5Y5ctRN84+I4iOZO61gm+48tgP/6Hcd3VZydkaEM3MCuOvnHRsTJYQBOc01faI/Z9at5nsCAJVHhlfPA6Pc0Og==",
+      "dev": true,
+      "requires": {
+        "caller": "^1.0.1"
+      }
     },
     "require-main-filename": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "mkdirp": "^0.5.1",
     "nock": "^11.7.0",
     "npmlog": "^4.1.2",
+    "require-inject": "^1.4.4",
     "rimraf": "^2.6.2",
     "ssri": "^7.1.0",
     "standard": "^14.3.1",

--- a/test/config.js
+++ b/test/config.js
@@ -1,22 +1,20 @@
 'use strict'
 
-const config = require('../config.js')
+const requireInject = require('require-inject')
+const config = requireInject('../config.js', {
+  '@npmcli/ci-detect': () => false
+})
 const npmlog = require('npmlog')
 const { test } = require('tap')
 
 npmlog.level = process.env.LOGLEVEL || 'silent'
 
 test('isFromCI config option', t => {
-  const CI = process.env.CI
-  process.env.CI = false
-  t.teardown(t => {
-    process.env.CI = CI
-  })
   const OPTS = config({
     log: npmlog,
     timeout: 0,
     registry: 'https://mock.reg/'
   })
-  t.notOk(OPTS.isFromCI, 'should be false if not on a CI env')
+  t.equal(OPTS.isFromCI, false, 'should be false if not on a CI env')
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -244,6 +244,30 @@ test('json()', t => {
     .then(json => t.deepEqual(json, { hello: 'world' }, 'got json body'))
 })
 
+test('query string with ?write=true', t => {
+  const cache = t.testdir()
+  const opts = OPTS.concat({ 'prefer-offline': true, cache })
+  const qsString = opts.concat({ query: { write: 'true' } })
+  const qsBool = opts.concat({ query: { write: true } })
+  tnock(t, opts.registry)
+    .get('/hello?write=true')
+    .times(6)
+    .reply(200, { write: 'go for it' })
+
+  return fetch.json('/hello?write=true', opts)
+    .then(res => t.strictSame(res, { write: 'go for it' }))
+    .then(() => fetch.json('/hello?write=true', opts))
+    .then(res => t.strictSame(res, { write: 'go for it' }))
+    .then(() => fetch.json('/hello', qsString))
+    .then(res => t.strictSame(res, { write: 'go for it' }))
+    .then(() => fetch.json('/hello', qsString))
+    .then(res => t.strictSame(res, { write: 'go for it' }))
+    .then(() => fetch.json('/hello', qsBool))
+    .then(res => t.strictSame(res, { write: 'go for it' }))
+    .then(() => fetch.json('/hello', qsBool))
+    .then(res => t.strictSame(res, { write: 'go for it' }))
+})
+
 test('fetch.json.stream()', t => {
   tnock(t, OPTS.registry).get('/hello').reply(200, {
     a: 1,


### PR DESCRIPTION
The npm CLI makes GET requests with ?write=true in some cases where it's
intending to send an immediate PUT or DELETE.  Always bypass the cache
for such requests, mirroring the behavior of the registry caching
mechanisms.

Pairing with @nomadtechie 