### PR TITLE
fix: use 30s default for timeout as per README

### DIFF
--- a/config.js
+++ b/config.js
@@ -69,7 +69,9 @@ module.exports = figgyPudding({
   scope: {},
   spec: {},
   'strict-ssl': {},
-  timeout: {},
+  timeout: {
+    default: 30 * 1000
+  },
   'user-agent': {
     default: `${
       pkg.name

--- a/test/config.js
+++ b/test/config.js
@@ -20,3 +20,13 @@ test('isFromCI config option', t => {
   t.notOk(OPTS.isFromCI, 'should be false if not on a CI env')
   t.end()
 })
+
+test('default timeout', t => {
+  const DEFAULT_OPTS = config({})
+  t.equal(DEFAULT_OPTS.timeout, 30 * 1000, 'default timeout is 30s')
+  const SPECIFIED_OPTS = config({
+    timeout: 15 * 1000
+  })
+  t.equal(SPECIFIED_OPTS.timeout, 15 * 1000, 'default timeout can be overridden')
+  t.end()
+})


### PR DESCRIPTION
# What / Why
The [README specifies](https://github.com/npm/npm-registry-fetch#-optstimeout) that the default for the timeout option is 30 seconds, but in reality [no default is set](https://github.com/npm/npm-registry-fetch/blob/5813da6/config.js#L72). This seems to result in the timeout depending on the OS's default TCP socket timeouts which can be very long.

## Background
I've been experiencing `$ npm install` occasionally hanging for long periods of time in docker image builds. When enabling `--verbose`  I see most `npm http fetch *` lines taking < 200ms but occasionally requests take more like 10 seconds, and less commonly hang for 5 minutes or so.

I assumed this was due to too much exponential backoff from the `retry` module, but in looking into this I noticed that npm doesn't document a timeout option (although setting a `timeout` in npm config does work), or _explicitly_ specify a timeout when using this module, and this module's specified default of 30 seconds is not actually used in practice – no default is currently defined.

The default exponential backoff from the `fetch-retry-*` settings imply a 10s pause after the first failure, then a 60s pause after the second failure, followed by a final attempt. This contributes to some of the time spent hanging, but not all of it. The long timeouts on each of the 3 possible failing fetches mean it can take many minutes for a fetch to actually fail. 

With the 30s default timeout, a fetch should take at most 2m40s to fail (30 + 10 + 30 + 60 + 30).

## References

  * Related to https://github.com/npm/npm/issues/8836
