### PR TITLE
fix: remove referer header and opts.refer

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,14 +501,6 @@ using
 If the request URI already has a query string, it will be merged with
 `opts.query`, preferring `opts.query` values.
 
-##### <a name="opts-refer"></a> `opts.refer`
-
-* Type: String
-* Default: null
-
-Value to use for the `Referer` header. The npm CLI itself uses this to serialize
-the npm command line using the given request.
-
 ##### <a name="opts-registry"></a> `opts.registry`
 
 * Type: URL

--- a/index.js
+++ b/index.js
@@ -113,7 +113,6 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
     method: method,
     noProxy: opts.noProxy,
     proxy: opts.httpsProxy || opts.proxy,
-    referer: opts.refer,
     retry: opts.retry ? opts.retry : {
       retries: opts.fetchRetries,
       factor: opts.fetchRetryFactor,
@@ -176,11 +175,16 @@ function getCacheMode (opts) {
 function getHeaders (registry, uri, opts) {
   const headers = Object.assign({
     'npm-in-ci': !!opts.isFromCI,
-    'npm-scope': opts.projectScope,
-    'npm-session': opts.npmSession,
-    'user-agent': opts.userAgent,
-    referer: opts.refer
+    'user-agent': opts.userAgent
   }, opts.headers || {})
+
+  if (opts.projectScope) {
+    headers['npm-scope'] = opts.projectScope
+  }
+
+  if (opts.npmSession) {
+    headers['npm-session'] = opts.npmSession
+  }
 
   const auth = getAuth(registry, opts)
   // If a tarball is hosted on a different place than the manifest, only send

--- a/test/index.js
+++ b/test/index.js
@@ -497,6 +497,26 @@ test('npm-in-ci header with forced CI=false', t => {
 // TODO
 // * npm-session
 // * npm-scope
-// * referer (opts.refer)
 // * user-agent
-test('miscellaneous headers')
+test('miscellaneous headers', t => {
+  tnock(t, OPTS.registry)
+    .matchHeader('npm-session', session =>
+      t.strictSame(session, ['foobarbaz'], 'session set from options'))
+    .matchHeader('npm-scope', scope =>
+      t.strictSame(scope, ['@foo'], 'scope set from options'))
+    .matchHeader('user-agent', ua =>
+      t.strictSame(ua, ['agent of use'], 'UA set from options'))
+    .matchHeader('npm-in-ci', ci =>
+      t.strictSame(ci, ['false'], 'CI set from options'))
+    .get('/hello')
+    .reply(200, { hello: 'world' })
+
+  return fetch('/hello', {
+    ...OPTS,
+    npmSession: 'foobarbaz',
+    projectScope: '@foo',
+    userAgent: 'agent of use'
+  }).then(res => {
+    t.equal(res.status, 200, 'got successful response')
+  })
+})


### PR DESCRIPTION
Re: https://github.com/npm/cli/issues/930

BREAKING CHANGE: Removes the 'opts.refer' option and the HTTP Referer
header (unless explicitly added to the 'headers' option, of course).
