### PR TITLE
Put default timeout back to zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ See also [`opts.ca`](#opts-ca).
 ##### <a name="opts-timeout"></a> `opts.timeout`
 
 * Type: Milliseconds
-* Default: 30000 (30 seconds)
+* Default: 0 (no timeout)
 
 Time before a hanging request times out.
 

--- a/config.js
+++ b/config.js
@@ -76,7 +76,7 @@ module.exports = figgyPudding({
   'spec': {},
   'strict-ssl': {},
   'timeout': {
-    default: 30 * 1000
+    default: 0
   },
   'user-agent': {
     default: `${

--- a/test/config.js
+++ b/test/config.js
@@ -23,7 +23,7 @@ test('isFromCI config option', t => {
 
 test('default timeout', t => {
   const DEFAULT_OPTS = config({})
-  t.equal(DEFAULT_OPTS.timeout, 30 * 1000, 'default timeout is 30s')
+  t.equal(DEFAULT_OPTS.timeout, 0, 'default timeout is 0 (no timeout)')
   const SPECIFIED_OPTS = config({
     timeout: 15 * 1000
   })


### PR DESCRIPTION
Re: https://github.com/npm/npm-registry-fetch/issues/26
Re: https://github.com/npm/cli/issues/1151

The documented default timeout of 30s was not being set in v4, so we
"fixed the glitch" in v4.0.3, causing problems for people trying to
download large packages.

There's no npm v6 way to specify what timeout to use, so not having a
timeout at all seems like a reasonable default for the v4 line, at
least. Let's roll back that change, and document it. (Arguably, fixing
this bug was a breaking change, and we ought to roll it back.)

This effectively reverts 69c297732cfe2d23f0303ab931a7b02364107388, with
documentation of the effective behavior before the change.
