### PR TITLE
Increase default timeout value from 30s to 5m

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ See also [`opts.ca`](#opts-ca).
 ##### <a name="opts-timeout"></a> `opts.timeout`
 
 * Type: Milliseconds
-* Default: 30000 (30 seconds)
+* Default: 300000 (5 minutes)
 
 Time before a hanging request times out.
 

--- a/default-opts.js
+++ b/default-opts.js
@@ -6,7 +6,7 @@ module.exports = {
   maxSockets: 12,
   method: 'GET',
   registry: 'https://registry.npmjs.org/',
-  timeout: 30 * 1000,
+  timeout: 5 * 60 * 1000, // 5 minutes
   strictSSL: true,
   noProxy: process.env.NOPROXY,
   userAgent: `${pkg.name


### PR DESCRIPTION
Re: https://github.com/npm/npm-registry-fetch/issues/26
Re: https://github.com/npm/cli/issues/1151

The previous default of 30s was too small for lots of users, causing
problems when they attempt to download large objects from the npm
registry.

Bump up the default timeout to 5m.

TODO: add a `--fetch-timeout` option on the CLI to explicitly set
`timeout` in the npm.flatOptions object passed to all dependencies.
