### PR TITLE
chore: hide sensitive data from logs

### DIFF
--- a/check-response.js
+++ b/check-response.js
@@ -30,9 +30,18 @@ function logRequest (method, res, startTime, opts) {
   const attempt = res.headers.get('x-fetch-attempts')
   const attemptStr = attempt && attempt > 1 ? ` attempt #${attempt}` : ''
   const cacheStr = res.headers.get('x-local-cache') ? ' (from cache)' : ''
+
+  let urlStr
+  try {
+    const url = new URL(res.url)
+    urlStr = res.url.replace(url.password, '***')
+  } catch {
+    urlStr = res.url
+  }
+
   opts.log.http(
     'fetch',
-    `${method.toUpperCase()} ${res.status} ${res.url} ${elapsedTime}ms${attemptStr}${cacheStr}`
+    `${method.toUpperCase()} ${res.status} ${urlStr} ${elapsedTime}ms${attemptStr}${cacheStr}`
   )
 }
 


### PR DESCRIPTION
Prevents `npm-registry-fetch` from leaking passwords on logs.