### PR TITLE
respect publishConfig.registry when specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
   }
   const registry = opts.registry = (
     (opts.spec && pickRegistry(opts.spec, opts)) ||
+    (opts.publishConfig && opts.publishConfig.registry) ||
     opts.registry ||
     /* istanbul ignore next */
     'https://registry.npmjs.org/'
@@ -153,6 +154,10 @@ function pickRegistry (spec, opts = {}) {
 
   if (!registry && opts.scope) {
     registry = opts[opts.scope.replace(/^@?/, '@') + ':registry']
+  }
+
+  if (!registry && opts.publishConfig) {
+    registry = opts.publishConfig.registry
   }
 
   if (!registry) {


### PR DESCRIPTION
This is the first part of restoring the `publishConfig.registry` field in package.json files, I chose to implement it in this way because the cli already sends the `publishConfig` property through for `npm unpublish` so allowing that to work without modification felt ideal.

There will be a follow up patch to the cli to also pass the `publishConfig` through for `npm publish` which currently does not take place.

For: https://github.com/npm/cli/issues/1937
