### PR TITLE
Remove publishConfig option

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
   }
   const registry = opts.registry = (
     (opts.spec && pickRegistry(opts.spec, opts)) ||
-    (opts.publishConfig && opts.publishConfig.registry) ||
     opts.registry ||
     /* istanbul ignore next */
     'https://registry.npmjs.org/'
@@ -151,9 +150,6 @@ function pickRegistry (spec, opts = {}) {
   if (!registry && opts.scope)
     registry = opts[opts.scope.replace(/^@?/, '@') + ':registry']
 
-  if (!registry && opts.publishConfig)
-    registry = opts.publishConfig.registry
-
   if (!registry)
     registry = opts.registry || 'https://registry.npmjs.org/'
 
@@ -163,7 +159,8 @@ function pickRegistry (spec, opts = {}) {
 function getCacheMode (opts) {
   return opts.offline ? 'only-if-cached'
     : opts.preferOffline ? 'force-cache'
-    : opts.preferOnline ? 'no-cache' : 'default'
+    : opts.preferOnline ? 'no-cache'
+    : 'default'
 }
 
 function getHeaders (registry, uri, opts) {

--- a/test/check-response.js
+++ b/test/check-response.js
@@ -71,7 +71,7 @@ test('log the url fetched', async t => {
     log: Object.assign({}, silentLog, {
       http (header, msg) {
         t.equal(header, 'fetch')
-        t.equal(msg, 'GET 200 http://example.com/foo/bar/baz 0ms')
+        t.match(msg, /^GET 200 http:\/\/example.com\/foo\/bar\/baz [0-9]+m?s/)
       },
     }),
   })
@@ -92,7 +92,7 @@ test('redact password from log', async t => {
     log: Object.assign({}, silentLog, {
       http (header, msg) {
         t.equal(header, 'fetch')
-        t.equal(msg, 'GET 200 http://username:***@example.com/foo/bar/baz 0ms')
+        t.match(msg, /^GET 200 http:\/\/username:\*\*\*@example.com\/foo\/bar\/baz [0-9]+m?s/)
       },
     }),
   })

--- a/test/index.js
+++ b/test/index.js
@@ -424,18 +424,6 @@ test('pickRegistry() utility', t => {
     'https://my.scoped.registry/here/',
     'scope @ is option@l'
   )
-  t.equal(
-    pick('foo@1.2.3', {
-      registry: 'https://my.registry/here/',
-      scope: '@otherscope',
-      '@myscope:registry': 'https://my.scoped.registry/here/',
-      publishConfig: {
-        registry: 'https://my.package.registry',
-      },
-    }),
-    'https://my.package.registry',
-    'respects publishConfig setting'
-  )
   t.done()
 })
 
@@ -473,34 +461,6 @@ test('pickRegistry through opts.spec', t => {
     scopedReg,
     'request made to scope registry using spec scope'
   ))
-})
-
-test('pickRegistry through publishConfig', t => {
-  tnock(t, OPTS.registry)
-    .get('/pkg')
-    .reply(200, { source: OPTS.registry })
-  const publishRegistry = 'https://my.publish.registry'
-  tnock(t, publishRegistry)
-    .get('/pkg')
-    .reply(200, { source: publishRegistry })
-
-  return fetch.json('/pkg', {
-    ...OPTS,
-    publishConfig: {},
-  }).then(json => t.equal(
-    json.source,
-    OPTS.registry,
-    'request made to default registry when publishConfig specifies no registry'
-  )).then(() => fetch.json('/pkg', {
-    ...OPTS,
-    publishConfig: {
-      registry: publishRegistry,
-    },
-  }).then(json => t.equal(
-    json.source,
-    publishRegistry,
-    'request made to publishConfig.registry when one is specified'
-  )))
 })
 
 test('log warning header info', t => {


### PR DESCRIPTION
Note: SemVer Major breaking change

This removes the 'publishConfig' option, as it will no longer be used
once npm/cli#2066 lands.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
