### PR TITLE
Load and send auth based on URI, not registry

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,55 +1,79 @@
 'use strict'
 
-const defaultOpts = require('./default-opts.js')
-const url = require('url')
+// Find the longest registry key that is used for some kind of auth
+// in the options.
+const regKeyFromURI = (uri, opts) => {
+  const parsed = new URL(uri)
+  // try to find a config key indicating we have auth for this registry
+  // can be one of :_authToken, :_auth, or :_password and :username
+  // We walk up the "path" until we're left with just //<host>[:<port>],
+  // stopping when we reach '//'.
+  let regKey = `//${parsed.host}${parsed.pathname}`
+  while (regKey.length > '//'.length) {
+    // got some auth for this URI
+    if (hasAuth(regKey, opts))
+      return regKey
+
+    // can be either //host/some/path/:_auth or //host/some/path:_auth
+    // walk up by removing EITHER what's after the slash OR the slash itself
+    regKey = regKey.replace(/([^/]+|\/)$/, '')
+  }
+}
+
+const hasAuth = (regKey, opts) => (
+  opts[`${regKey}:_authToken`] ||
+  opts[`${regKey}:_auth`] ||
+  opts[`${regKey}:username`] && opts[`${regKey}:_password`]
+)
+
+const getAuth = (uri, opts = {}) => {
+  const { forceAuth } = opts
+  if (!uri)
+    throw new Error('URI is required')
+  const regKey = regKeyFromURI(uri, forceAuth || opts)
+
+  // we are only allowed to use what's in forceAuth if specified
+  if (forceAuth && !regKey) {
+    return new Auth({
+      token: forceAuth._authToken,
+      username: forceAuth.username,
+      password: forceAuth._password || forceAuth.password,
+      auth: forceAuth._auth || forceAuth.auth,
+    })
+  }
+
+  // no auth for this URI
+  if (!regKey)
+    return new Auth({})
+
+  const {
+    [`${regKey}:_authToken`]: token,
+    [`${regKey}:username`]: username,
+    [`${regKey}:_password`]: password,
+    [`${regKey}:_auth`]: auth,
+  } = opts
+
+  return new Auth({
+    token,
+    auth,
+    username,
+    password,
+  })
+}
+
+class Auth {
+  constructor ({ token, auth, username, password }) {
+    this.token = null
+    this.auth = null
+    if (token)
+      this.token = token
+    else if (auth)
+      this.auth = auth
+    else if (username && password) {
+      const p = Buffer.from(password, 'base64').toString('utf8')
+      this.auth = Buffer.from(`${username}:${p}`, 'utf8').toString('base64')
+    }
+  }
+}
 
 module.exports = getAuth
-function getAuth (registry, opts_ = {}) {
-  if (!registry)
-    throw new Error('registry is required')
-  const opts = opts_.forceAuth ? opts_.forceAuth : { ...defaultOpts, ...opts_ }
-  const AUTH = {}
-  const regKey = registry && registryKey(registry)
-  const doKey = (key, alias) => addKey(opts, AUTH, regKey, key, alias)
-  doKey('token')
-  doKey('_authToken', 'token')
-  doKey('username')
-  doKey('password')
-  doKey('_password', 'password')
-  doKey('email')
-  doKey('_auth')
-  doKey('otp')
-  doKey('always-auth', 'alwaysAuth')
-  if (AUTH.password)
-    AUTH.password = Buffer.from(AUTH.password, 'base64').toString('utf8')
-
-  if (AUTH._auth && !(AUTH.username && AUTH.password)) {
-    let auth = Buffer.from(AUTH._auth, 'base64').toString()
-    auth = auth.split(':')
-    AUTH.username = auth.shift()
-    AUTH.password = auth.join(':')
-  }
-  AUTH.alwaysAuth = AUTH.alwaysAuth === 'false' ? false : !!AUTH.alwaysAuth
-  return AUTH
-}
-
-function addKey (opts, obj, scope, key, objKey) {
-  if (opts[key])
-    obj[objKey || key] = opts[key]
-
-  if (scope && opts[`${scope}:${key}`])
-    obj[objKey || key] = opts[`${scope}:${key}`]
-}
-
-// Called a nerf dart in the main codebase. Used as a "safe"
-// key when fetching registry info from config.
-function registryKey (registry) {
-  const parsed = new url.URL(registry)
-  const formatted = url.format({
-    protocol: parsed.protocol,
-    host: parsed.host,
-    pathname: parsed.pathname,
-    slashes: true,
-  })
-  return url.format(new url.URL('.', formatted)).replace(/^[^:]+:/, '')
-}

--- a/errors.js
+++ b/errors.js
@@ -22,6 +22,7 @@ function packageName (href) {
 class HttpErrorBase extends Error {
   constructor (method, res, body, spec) {
     super()
+    this.name = this.constructor.name
     this.headers = res.headers.raw()
     this.statusCode = res.status
     this.code = `E${res.status}`

--- a/index.js
+++ b/index.js
@@ -27,26 +27,31 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
     ...defaultOpts,
     ...opts_,
   }
-  const registry = opts.registry = (
-    (opts.spec && pickRegistry(opts.spec, opts)) ||
-    opts.registry ||
-    /* istanbul ignore next */
-    'https://registry.npmjs.org/'
-  )
 
-  if (!urlIsValid(uri)) {
+  // if we did not get a fully qualified URI, then we look at the registry
+  // config or relevant scope to resolve it.
+  const uriValid = urlIsValid(uri)
+  let registry = opts.registry || defaultOpts.registry
+  if (!uriValid) {
+    registry = opts.registry = (
+      (opts.spec && pickRegistry(opts.spec, opts)) ||
+      opts.registry ||
+      registry
+    )
     uri = `${
       registry.trim().replace(/\/?$/g, '')
     }/${
       uri.trim().replace(/^\//, '')
     }`
+    // asserts that this is now valid
+    new url.URL(uri)
   }
 
   const method = opts.method || 'GET'
 
   // through that takes into account the scope, the prefix of `uri`, etc
   const startTime = Date.now()
-  const headers = getHeaders(registry, uri, opts)
+  const headers = getHeaders(uri, opts)
   let body = opts.body
   const bodyIsStream = Minipass.isStream(body)
   const bodyIsPromise = body &&
@@ -151,7 +156,7 @@ function pickRegistry (spec, opts = {}) {
     registry = opts[opts.scope.replace(/^@?/, '@') + ':registry']
 
   if (!registry)
-    registry = opts.registry || 'https://registry.npmjs.org/'
+    registry = opts.registry || defaultOpts.registry
 
   return registry
 }
@@ -163,7 +168,7 @@ function getCacheMode (opts) {
     : 'default'
 }
 
-function getHeaders (registry, uri, opts) {
+function getHeaders (uri, opts) {
   const headers = Object.assign({
     'npm-in-ci': !!opts.isFromCI,
     'user-agent': opts.userAgent,
@@ -178,25 +183,16 @@ function getHeaders (registry, uri, opts) {
   if (opts.npmCommand)
     headers['npm-command'] = opts.npmCommand
 
-  const auth = getAuth(registry, opts)
+  const auth = getAuth(uri, opts)
   // If a tarball is hosted on a different place than the manifest, only send
   // credentials on `alwaysAuth`
-  const shouldAuth = (
-    auth.alwaysAuth ||
-    new url.URL(uri).host === new url.URL(registry).host
-  )
-  if (shouldAuth && auth.token)
+  if (auth.token)
     headers.authorization = `Bearer ${auth.token}`
-  else if (shouldAuth && auth.username && auth.password) {
-    const encoded = Buffer.from(
-      `${auth.username}:${auth.password}`, 'utf8'
-    ).toString('base64')
-    headers.authorization = `Basic ${encoded}`
-  } else if (shouldAuth && auth._auth)
-    headers.authorization = `Basic ${auth._auth}`
+  else if (auth.auth)
+    headers.authorization = `Basic ${auth.auth}`
 
-  if (shouldAuth && auth.otp)
-    headers['npm-otp'] = auth.otp
+  if (opts.otp)
+    headers['npm-otp'] = opts.otp
 
   return headers
 }

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const npmlog = require('npmlog')
-const test = require('tap').test
+const t = require('tap')
 const tnock = require('./util/tnock.js')
 
 const fetch = require('../index.js')
@@ -20,7 +20,7 @@ const OPTS = {
   registry: 'https://mock.reg/',
 }
 
-test('basic auth', t => {
+t.test('basic auth', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',
     username: 'globaluser',
@@ -49,7 +49,7 @@ test('basic auth', t => {
     .then(res => t.equal(res, 'success', 'basic auth succeeded'))
 })
 
-test('token auth', t => {
+t.test('token auth', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',
     token: 'deadbeef',
@@ -58,7 +58,7 @@ test('token auth', t => {
     '//my.custom.registry/:_authToken': 'c0ffee',
     '//my.custom.registry/:token': 'nope',
   }
-  t.deepEqual(getAuth(`${config.registry}/foo/-/foo.tgz`, config), {
+  t.same(getAuth(`${config.registry}/foo/-/foo.tgz`, config), {
     token: 'c0ffee',
     auth: null,
   }, 'correct auth token picked out')
@@ -75,7 +75,7 @@ test('token auth', t => {
     .then(res => t.equal(res, 'success', 'token auth succeeded'))
 })
 
-test('forceAuth', t => {
+t.test('forceAuth', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',
     token: 'deadbeef',
@@ -89,7 +89,7 @@ test('forceAuth', t => {
       'always-auth': true,
     },
   }
-  t.deepEqual(getAuth(config.registry, config), {
+  t.same(getAuth(config.registry, config), {
     token: null,
     auth: Buffer.from('user:pass').toString('base64'),
   }, 'only forceAuth details included')
@@ -107,7 +107,7 @@ test('forceAuth', t => {
     .then(res => t.equal(res, 'success', 'used forced auth details'))
 })
 
-test('_auth auth', t => {
+t.test('_auth auth', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',
     _auth: 'deadbeef',
@@ -128,7 +128,7 @@ test('_auth auth', t => {
     .then(res => t.equal(res, 'success', '_auth auth succeeded'))
 })
 
-test('_auth username:pass auth', t => {
+t.test('_auth username:pass auth', t => {
   const username = 'foo'
   const password = 'bar'
   const auth = Buffer.from(`${username}:${password}`, 'utf8').toString('base64')
@@ -151,7 +151,7 @@ test('_auth username:pass auth', t => {
     .then(res => t.equal(res, 'success', '_auth auth succeeded'))
 })
 
-test('ignore user/pass when _auth is set', t => {
+t.test('ignore user/pass when _auth is set', t => {
   const username = 'foo'
   const password = Buffer.from('bar', 'utf8').toString('base64')
   const auth = Buffer.from('not:foobar', 'utf8').toString('base64')
@@ -172,7 +172,7 @@ test('ignore user/pass when _auth is set', t => {
   t.end()
 })
 
-test('globally-configured auth', t => {
+t.test('globally-configured auth', t => {
   const basicConfig = {
     registry: 'https://different.registry/',
     '//different.registry/:username': 'globaluser',
@@ -182,7 +182,7 @@ test('globally-configured auth', t => {
     '//my.custom.registry/here/:_password': Buffer.from('pass', 'utf8').toString('base64'),
     '//my.custom.registry/here/:email': 'e@ma.il',
   }
-  t.deepEqual(getAuth(basicConfig.registry, basicConfig), {
+  t.same(getAuth(basicConfig.registry, basicConfig), {
     token: null,
     auth: Buffer.from('globaluser:globalpass').toString('base64'),
   }, 'basic auth details generated from global settings')
@@ -193,7 +193,7 @@ test('globally-configured auth', t => {
     '//my.custom.registry/here/:_authToken': 'c0ffee',
     '//my.custom.registry/here/:token': 'nope',
   }
-  t.deepEqual(getAuth(tokenConfig.registry, tokenConfig), {
+  t.same(getAuth(tokenConfig.registry, tokenConfig), {
     token: 'deadbeef',
     auth: null,
   }, 'correct global auth token picked out')
@@ -209,10 +209,10 @@ test('globally-configured auth', t => {
     auth: 'deadbeef',
   }, 'correct _auth picked out')
 
-  t.done()
+  t.end()
 })
 
-test('otp token passed through', t => {
+t.test('otp token passed through', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',
     token: 'deadbeef',
@@ -220,7 +220,7 @@ test('otp token passed through', t => {
     '//my.custom.registry/here/:_authToken': 'c0ffee',
     '//my.custom.registry/here/:token': 'nope',
   }
-  t.deepEqual(getAuth(config.registry, config), {
+  t.same(getAuth(config.registry, config), {
     token: 'c0ffee',
     auth: null,
   }, 'correct auth token picked out')
@@ -238,7 +238,7 @@ test('otp token passed through', t => {
     .then(res => t.equal(res, 'success', 'otp auth succeeded'))
 })
 
-test('different hosts for uri vs registry', t => {
+t.test('different hosts for uri vs registry', t => {
   const config = {
     'always-auth': false,
     registry: 'https://my.custom.registry/here/',
@@ -259,7 +259,7 @@ test('different hosts for uri vs registry', t => {
     .then(res => t.equal(res, 'success', 'token auth succeeded'))
 })
 
-test('http vs https auth sending', t => {
+t.test('http vs https auth sending', t => {
   const config = {
     'always-auth': false,
     registry: 'https://my.custom.registry/here/',
@@ -277,7 +277,7 @@ test('http vs https auth sending', t => {
     .then(res => t.equal(res, 'success', 'token auth succeeded'))
 })
 
-test('always-auth', t => {
+t.test('always-auth', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',
     'always-auth': 'true',
@@ -299,7 +299,7 @@ test('always-auth', t => {
     .then(res => t.equal(res, 'success', 'token auth succeeded'))
 })
 
-test('scope-based auth', t => {
+t.test('scope-based auth', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',
     scope: '@myscope',
@@ -308,11 +308,11 @@ test('scope-based auth', t => {
     '//my.custom.registry/here/:_authToken': 'c0ffee',
     '//my.custom.registry/here/:token': 'nope',
   }
-  t.deepEqual(getAuth(config['@myscope:registry'], config), {
+  t.same(getAuth(config['@myscope:registry'], config), {
     auth: null,
     token: 'c0ffee',
   }, 'correct auth token picked out')
-  t.deepEqual(getAuth(config['@myscope:registry'], config), {
+  t.same(getAuth(config['@myscope:registry'], config), {
     auth: null,
     token: 'c0ffee',
   }, 'correct auth token picked out without scope config having an @')
@@ -334,12 +334,12 @@ test('scope-based auth', t => {
     .then(res => t.equal(res, 'success', 'token auth succeeded without @ in scope'))
 })
 
-test('auth needs a uri', t => {
+t.test('auth needs a uri', t => {
   t.throws(() => getAuth(null), { message: 'URI is required' })
   t.end()
 })
 
-test('do not be thrown by other weird configs', t => {
+t.test('do not be thrown by other weird configs', t => {
   const opts = {
     scope: '@asdf',
     '@asdf:_authToken': 'does this work?',

--- a/test/cache.js
+++ b/test/cache.js
@@ -4,7 +4,7 @@ const { promisify } = require('util')
 const statAsync = promisify(require('fs').stat)
 const npmlog = require('npmlog')
 const path = require('path')
-const test = require('tap').test
+const t = require('tap')
 const tnock = require('./util/tnock.js')
 
 const fetch = require('../index.js')
@@ -27,57 +27,57 @@ const OPTS = {
   registry: REGISTRY,
 }
 
-test('can cache GET requests', t => {
+t.test('can cache GET requests', t => {
   tnock(t, REGISTRY)
     .get('/normal')
     .times(1)
     .reply(200, { obj: 'value' })
   return fetch.json('/normal', OPTS)
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'got expected response'))
+    .then(val => t.same(val, { obj: 'value' }, 'got expected response'))
     .then(() => statAsync(OPTS.cache))
     .then(stat => t.ok(stat.isDirectory(), 'cache directory created'))
     .then(() => fetch.json('/normal', OPTS))
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'response was cached'))
+    .then(val => t.same(val, { obj: 'value' }, 'response was cached'))
 })
 
-test('preferOffline', t => {
+t.test('preferOffline', t => {
   tnock(t, REGISTRY)
     .get('/preferOffline')
     .times(1)
     .reply(200, { obj: 'value' })
   return fetch.json('/preferOffline', { ...OPTS, preferOffline: true })
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'got expected response'))
+    .then(val => t.same(val, { obj: 'value' }, 'got expected response'))
     .then(() => statAsync(OPTS.cache))
     .then(stat => t.ok(stat.isDirectory(), 'cache directory created'))
     .then(() => fetch.json('/preferOffline', { ...OPTS, preferOffline: true }))
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'response was cached'))
+    .then(val => t.same(val, { obj: 'value' }, 'response was cached'))
 })
 
-test('offline', t => {
+t.test('offline', t => {
   tnock(t, REGISTRY)
     .get('/offline')
     .times(1)
     .reply(200, { obj: 'value' })
   return fetch.json('/offline', OPTS)
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'got expected response'))
+    .then(val => t.same(val, { obj: 'value' }, 'got expected response'))
     .then(() => statAsync(OPTS.cache))
     .then(stat => t.ok(stat.isDirectory(), 'cache directory created'))
     .then(() => fetch.json('/offline', { ...OPTS, offline: true }))
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'response was cached'))
+    .then(val => t.same(val, { obj: 'value' }, 'response was cached'))
 })
 
-test('offline fails if not cached', t =>
+t.test('offline fails if not cached', t =>
   t.rejects(() => fetch('/offline-fails', { ...OPTS, offline: true })))
 
-test('preferOnline', t => {
+t.test('preferOnline', t => {
   tnock(t, REGISTRY)
     .get('/preferOnline')
     .times(2)
     .reply(200, { obj: 'value' })
   return fetch.json('/preferOnline', OPTS)
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'got expected response'))
+    .then(val => t.same(val, { obj: 'value' }, 'got expected response'))
     .then(() => statAsync(OPTS.cache))
     .then(stat => t.ok(stat.isDirectory(), 'cache directory created'))
     .then(() => fetch.json('/preferOnline', { ...OPTS, preferOnline: true }))
-    .then(val => t.deepEqual(val, { obj: 'value' }, 'response was refetched'))
+    .then(val => t.same(val, { obj: 'value' }, 'response was refetched'))
 })

--- a/test/errors.js
+++ b/test/errors.js
@@ -2,7 +2,7 @@
 
 const npa = require('npm-package-arg')
 const npmlog = require('npmlog')
-const test = require('tap').test
+const t = require('tap')
 const tnock = require('./util/tnock.js')
 
 const fetch = require('../index.js')
@@ -20,7 +20,7 @@ const OPTS = {
   registry: 'https://mock.reg/',
 }
 
-test('generic request errors', t => {
+t.test('generic request errors', t => {
   tnock(t, OPTS.registry)
     .get('/ohno/oops')
     .reply(400, 'failwhale!')
@@ -44,7 +44,7 @@ test('generic request errors', t => {
     )
 })
 
-test('pkgid tie fighter', t => {
+t.test('pkgid tie fighter', t => {
   tnock(t, OPTS.registry)
     .get('/-/ohno/_rewrite/ohyeah/maybe')
     .reply(400, 'failwhale!')
@@ -57,7 +57,7 @@ test('pkgid tie fighter', t => {
     )
 })
 
-test('pkgid _rewrite', t => {
+t.test('pkgid _rewrite', t => {
   tnock(t, OPTS.registry)
     .get('/ohno/_rewrite/ohyeah/maybe')
     .reply(400, 'failwhale!')
@@ -70,7 +70,7 @@ test('pkgid _rewrite', t => {
     )
 })
 
-test('pkgid with `opts.spec`', t => {
+t.test('pkgid with `opts.spec`', t => {
   tnock(t, OPTS.registry)
     .get('/ohno/_rewrite/ohyeah')
     .reply(400, 'failwhale!')
@@ -86,7 +86,7 @@ test('pkgid with `opts.spec`', t => {
     )
 })
 
-test('JSON error reporing', t => {
+t.test('JSON error reporing', t => {
   tnock(t, OPTS.registry)
     .get('/ohno')
     .reply(400, { error: 'badarg' })
@@ -111,7 +111,7 @@ test('JSON error reporing', t => {
     )
 })
 
-test('OTP error', t => {
+t.test('OTP error', t => {
   tnock(t, OPTS.registry)
     .get('/otplease')
     .reply(401, { error: 'needs an otp, please' }, {
@@ -128,7 +128,7 @@ test('OTP error', t => {
     )
 })
 
-test('OTP error when missing www-authenticate', t => {
+t.test('OTP error when missing www-authenticate', t => {
   tnock(t, OPTS.registry)
     .get('/otplease')
     .reply(401, { error: 'needs a one-time password' })
@@ -143,7 +143,7 @@ test('OTP error when missing www-authenticate', t => {
     )
 })
 
-test('Bad IP address error', t => {
+t.test('Bad IP address error', t => {
   tnock(t, OPTS.registry)
     .get('/badaddr')
     .reply(401, { error: 'you are using the wrong IP address, friend' }, {
@@ -160,7 +160,7 @@ test('Bad IP address error', t => {
     )
 })
 
-test('Unexpected www-authenticate error', t => {
+t.test('Unexpected www-authenticate error', t => {
   tnock(t, OPTS.registry)
     .get('/unown')
     .reply(401, {
@@ -185,4 +185,4 @@ test('Unexpected www-authenticate error', t => {
     )
 })
 
-test('retries certain types')
+t.test('retries certain types')

--- a/test/index.js
+++ b/test/index.js
@@ -4,9 +4,16 @@ const Minipass = require('minipass')
 const npmlog = require('npmlog')
 const silentLog = require('../silentlog.js')
 const ssri = require('ssri')
-const test = require('tap').test
+const t = require('tap')
 const tnock = require('./util/tnock.js')
 const zlib = require('zlib')
+const defaultOpts = require('../default-opts.js')
+
+t.equal(defaultOpts.registry, 'https://registry.npmjs.org/',
+  'default registry is the npm public registry')
+
+// ok, now change it for the tests
+defaultOpts.registry = 'https://mock.reg/'
 
 const fetch = require('../index.js')
 
@@ -23,11 +30,10 @@ const OPTS = {
     minTimeout: 1,
     maxTimeout: 10,
   },
-  registry: 'https://mock.reg/',
 }
 
-test('hello world', t => {
-  tnock(t, OPTS.registry)
+t.test('hello world', t => {
+  tnock(t, defaultOpts.registry)
     .get('/hello')
     .reply(200, { hello: 'world' })
   return fetch('/hello', {
@@ -41,8 +47,8 @@ test('hello world', t => {
     .then(json => t.deepEqual(json, { hello: 'world' }, 'got correct body'))
 })
 
-test('JSON body param', t => {
-  tnock(t, OPTS.registry)
+t.test('JSON body param', t => {
+  tnock(t, defaultOpts.registry)
     .matchHeader('content-type', ctype => {
       t.equal(ctype[0], 'application/json', 'content-type automatically set')
       return ctype[0] === 'application/json'
@@ -67,8 +73,8 @@ test('JSON body param', t => {
     .then(json => t.deepEqual(json, { hello: 'world' }))
 })
 
-test('buffer body param', t => {
-  tnock(t, OPTS.registry)
+t.test('buffer body param', t => {
+  tnock(t, defaultOpts.registry)
     .matchHeader('content-type', ctype => {
       t.equal(ctype[0], 'application/octet-stream', 'content-type automatically set')
       return ctype[0] === 'application/octet-stream'
@@ -97,8 +103,8 @@ test('buffer body param', t => {
     )
 })
 
-test('stream body param', t => {
-  tnock(t, OPTS.registry)
+t.test('stream body param', t => {
+  tnock(t, defaultOpts.registry)
     .matchHeader('content-type', ctype => {
       t.equal(ctype[0], 'application/octet-stream', 'content-type automatically set')
       return ctype[0] === 'application/octet-stream'
@@ -125,8 +131,8 @@ test('stream body param', t => {
     .then(json => t.deepEqual(json, { hello: 'world' }))
 })
 
-test('JSON body param', t => {
-  tnock(t, OPTS.registry)
+t.test('JSON body param', t => {
+  tnock(t, defaultOpts.registry)
     .matchHeader('content-type', ctype => {
       t.equal(ctype[0], 'application/json', 'content-type automatically set')
       return ctype[0] === 'application/json'
@@ -150,8 +156,8 @@ test('JSON body param', t => {
     })
 })
 
-test('gzip + buffer body param', t => {
-  tnock(t, OPTS.registry)
+t.test('gzip + buffer body param', t => {
+  tnock(t, defaultOpts.registry)
     .matchHeader('content-type', ctype => {
       t.equal(ctype[0], 'application/octet-stream', 'content-type automatically set')
       return ctype[0] === 'application/octet-stream'
@@ -186,8 +192,8 @@ test('gzip + buffer body param', t => {
     )
 })
 
-test('gzip + stream body param', t => {
-  tnock(t, OPTS.registry)
+t.test('gzip + stream body param', t => {
+  tnock(t, defaultOpts.registry)
     .matchHeader('content-type', ctype => {
       t.equal(ctype[0], 'application/octet-stream', 'content-type automatically set')
       return ctype[0] === 'application/octet-stream'
@@ -224,8 +230,8 @@ test('gzip + stream body param', t => {
     .then(json => t.deepEqual(json, { hello: 'world' }))
 })
 
-test('query strings', t => {
-  tnock(t, OPTS.registry)
+t.test('query strings', t => {
+  tnock(t, defaultOpts.registry)
     .get('/hello?hi=there&who=wor%20ld')
     .reply(200, { hello: 'world' })
   return fetch.json('/hello?hi=there', {
@@ -234,8 +240,8 @@ test('query strings', t => {
   }).then(json => t.equal(json.hello, 'world', 'query-string merged'))
 })
 
-test('query strings - undefined values', t => {
-  tnock(t, OPTS.registry)
+t.test('query strings - undefined values', t => {
+  tnock(t, defaultOpts.registry)
     .get('/hello?who=wor%20ld')
     .reply(200, { ok: true })
   return fetch.json('/hello', {
@@ -244,20 +250,20 @@ test('query strings - undefined values', t => {
   }).then(json => t.ok(json.ok, 'undefined keys not included in query string'))
 })
 
-test('json()', t => {
-  tnock(t, OPTS.registry)
+t.test('json()', t => {
+  tnock(t, defaultOpts.registry)
     .get('/hello')
     .reply(200, { hello: 'world' })
   return fetch.json('/hello', OPTS)
     .then(json => t.deepEqual(json, { hello: 'world' }, 'got json body'))
 })
 
-test('query string with ?write=true', t => {
+t.test('query string with ?write=true', t => {
   const cache = t.testdir()
   const opts = { ...OPTS, preferOffline: true, cache }
   const qsString = { ...opts, query: { write: 'true' } }
   const qsBool = { ...opts, query: { write: true } }
-  tnock(t, opts.registry)
+  tnock(t, defaultOpts.registry)
     .get('/writeTrueTest?write=true')
     .times(6)
     .reply(200, { write: 'go for it' })
@@ -276,8 +282,8 @@ test('query string with ?write=true', t => {
     .then(res => t.strictSame(res, { write: 'go for it' }))
 })
 
-test('fetch.json.stream()', t => {
-  tnock(t, OPTS.registry).get('/hello').reply(200, {
+t.test('fetch.json.stream()', t => {
+  tnock(t, defaultOpts.registry).get('/hello').reply(200, {
     a: 1,
     b: 2,
     c: 3,
@@ -291,8 +297,8 @@ test('fetch.json.stream()', t => {
   })
 })
 
-test('fetch.json.stream opts.mapJSON', t => {
-  tnock(t, OPTS.registry).get('/hello').reply(200, {
+t.test('fetch.json.stream opts.mapJSON', t => {
+  tnock(t, defaultOpts.registry).get('/hello').reply(200, {
     a: 1,
     b: 2,
     c: 3,
@@ -311,7 +317,7 @@ test('fetch.json.stream opts.mapJSON', t => {
   })
 })
 
-test('fetch.json.stream gets fetch error on stream', t => {
+t.test('fetch.json.stream gets fetch error on stream', t => {
   return t.rejects(fetch.json.stream('/hello', '*', {
     ...OPTS,
     body: Promise.reject(new Error('no body for you')),
@@ -322,8 +328,8 @@ test('fetch.json.stream gets fetch error on stream', t => {
   })
 })
 
-test('opts.ignoreBody', t => {
-  tnock(t, OPTS.registry)
+t.test('opts.ignoreBody', t => {
+  tnock(t, defaultOpts.registry)
     .get('/hello')
     .reply(200, { hello: 'world' })
   return fetch('/hello', { ...OPTS, ignoreBody: true })
@@ -332,8 +338,8 @@ test('opts.ignoreBody', t => {
     })
 })
 
-test('method configurable', t => {
-  tnock(t, OPTS.registry)
+t.test('method configurable', t => {
+  tnock(t, defaultOpts.registry)
     .delete('/hello')
     .reply(200)
   const opts = {
@@ -346,8 +352,8 @@ test('method configurable', t => {
     })
 })
 
-test('npm-notice header logging', t => {
-  tnock(t, OPTS.registry)
+t.test('npm-notice header logging', t => {
+  tnock(t, defaultOpts.registry)
     .get('/hello')
     .reply(200, { hello: 'world' }, {
       'npm-notice': 'npm <3 u',
@@ -366,9 +372,9 @@ test('npm-notice header logging', t => {
     .then(res => t.equal(res.status, 200, 'got successful response'))
 })
 
-test('optionally verifies request body integrity', t => {
+t.test('optionally verifies request body integrity', t => {
   t.plan(3)
-  tnock(t, OPTS.registry)
+  tnock(t, defaultOpts.registry)
     .get('/hello')
     .times(2)
     .reply(200, 'hello')
@@ -394,9 +400,9 @@ test('optionally verifies request body integrity', t => {
     })
 })
 
-test('pickRegistry() utility', t => {
+t.test('pickRegistry() utility', t => {
   const pick = fetch.pickRegistry
-  t.equal(pick('foo@1.2.3'), 'https://registry.npmjs.org/', 'has good default')
+  t.equal(pick('foo@1.2.3'), defaultOpts.registry, 'has good default')
   t.equal(
     pick('foo@1.2.3', {
       registry: 'https://my.registry/here/',
@@ -427,10 +433,10 @@ test('pickRegistry() utility', t => {
   t.done()
 })
 
-test('pickRegistry through opts.spec', t => {
-  tnock(t, OPTS.registry)
+t.test('pickRegistry through opts.spec', t => {
+  tnock(t, defaultOpts.registry)
     .get('/pkg')
-    .reply(200, { source: OPTS.registry })
+    .reply(200, { source: defaultOpts.registry })
   const scopedReg = 'https://scoped.mock.reg/'
   tnock(t, scopedReg)
     .get('/pkg')
@@ -442,7 +448,7 @@ test('pickRegistry through opts.spec', t => {
     '@myscope:registry': scopedReg,
   }).then(json => t.equal(
     json.source,
-    OPTS.registry,
+    defaultOpts.registry,
     'request made to main registry'
   )).then(() => fetch.json('/pkg', {
     ...OPTS,
@@ -463,8 +469,8 @@ test('pickRegistry through opts.spec', t => {
   ))
 })
 
-test('log warning header info', t => {
-  tnock(t, OPTS.registry)
+t.test('log warning header info', t => {
+  tnock(t, defaultOpts.registry)
     .get('/hello')
     .reply(200, { hello: 'world' }, { Warning: '199 - "ENOTFOUND" "Wed, 21 Oct 2015 07:28:00 GMT"' })
   const opts = {
@@ -472,7 +478,7 @@ test('log warning header info', t => {
     log: Object.assign({}, silentLog, {
       warn (header, msg) {
         t.equal(header, 'registry', 'expected warn log header')
-        t.equal(msg, `Using stale data from ${OPTS.registry} because the host is inaccessible -- are you offline?`, 'logged out at WARNING level')
+        t.equal(msg, `Using stale data from ${defaultOpts.registry} because the host is inaccessible -- are you offline?`, 'logged out at WARNING level')
       },
     }),
   }
@@ -481,13 +487,13 @@ test('log warning header info', t => {
     .then(res => t.equal(res.status, 200, 'got successful response'))
 })
 
-test('npm-in-ci header with forced CI=false', t => {
+t.test('npm-in-ci header with forced CI=false', t => {
   const CI = process.env.CI
   process.env.CI = false
   t.teardown(t => {
     process.env.CI = CI
   })
-  tnock(t, OPTS.registry)
+  tnock(t, defaultOpts.registry)
     .get('/hello')
     .reply(200, { hello: 'world' })
   return fetch('/hello', OPTS)
@@ -496,8 +502,8 @@ test('npm-in-ci header with forced CI=false', t => {
     })
 })
 
-test('miscellaneous headers', t => {
-  tnock(t, OPTS.registry)
+t.test('miscellaneous headers', t => {
+  tnock(t, defaultOpts.registry)
     .matchHeader('npm-session', session =>
       t.strictSame(session, ['foobarbaz'], 'session set from options'))
     .matchHeader('npm-scope', scope =>
@@ -513,6 +519,7 @@ test('miscellaneous headers', t => {
 
   return fetch('/hello', {
     ...OPTS,
+    registry: null, // always falls back on falsey registry value
     npmSession: 'foobarbaz',
     projectScope: '@foo',
     userAgent: 'agent of use',

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ t.test('hello world', t => {
       t.equal(res.status, 200, 'got successful response')
       return res.json()
     })
-    .then(json => t.deepEqual(json, { hello: 'world' }, 'got correct body'))
+    .then(json => t.same(json, { hello: 'world' }, 'got correct body'))
 })
 
 t.test('JSON body param', t => {
@@ -55,7 +55,7 @@ t.test('JSON body param', t => {
     })
     .post('/hello')
     .reply(200, (uri, reqBody) => {
-      t.deepEqual(reqBody, {
+      t.same(reqBody, {
         hello: 'world',
       }, 'got the JSON version of the body')
       return reqBody
@@ -70,7 +70,7 @@ t.test('JSON body param', t => {
       t.equal(res.status, 200)
       return res.json()
     })
-    .then(json => t.deepEqual(json, { hello: 'world' }))
+    .then(json => t.same(json, { hello: 'world' }))
 })
 
 t.test('buffer body param', t => {
@@ -81,7 +81,7 @@ t.test('buffer body param', t => {
     })
     .post('/hello')
     .reply(200, (uri, reqBody) => {
-      t.deepEqual(
+      t.same(
         Buffer.from(reqBody, 'utf8'),
         Buffer.from('hello', 'utf8'),
         'got the JSON version of the body'
@@ -99,7 +99,7 @@ t.test('buffer body param', t => {
       return res.buffer()
     })
     .then(buf =>
-      t.deepEqual(buf, Buffer.from('hello', 'utf8'), 'got response')
+      t.same(buf, Buffer.from('hello', 'utf8'), 'got response')
     )
 })
 
@@ -111,7 +111,7 @@ t.test('stream body param', t => {
     })
     .post('/hello')
     .reply(200, (uri, reqBody) => {
-      t.deepEqual(JSON.parse(reqBody), {
+      t.same(JSON.parse(reqBody), {
         hello: 'world',
       }, 'got the stringified version of the body')
       return reqBody
@@ -128,7 +128,7 @@ t.test('stream body param', t => {
       t.equal(res.status, 200)
       return res.json()
     })
-    .then(json => t.deepEqual(json, { hello: 'world' }))
+    .then(json => t.same(json, { hello: 'world' }))
 })
 
 t.test('JSON body param', t => {
@@ -169,7 +169,7 @@ t.test('gzip + buffer body param', t => {
     .post('/hello')
     .reply(200, (uri, reqBody) => {
       reqBody = zlib.gunzipSync(Buffer.from(reqBody, 'hex'))
-      t.deepEqual(
+      t.same(
         Buffer.from(reqBody, 'utf8').toString('utf8'),
         'hello',
         'got the JSON version of the body'
@@ -188,7 +188,7 @@ t.test('gzip + buffer body param', t => {
       return res.buffer()
     })
     .then(buf =>
-      t.deepEqual(buf, Buffer.from('hello', 'utf8'), 'got response')
+      t.same(buf, Buffer.from('hello', 'utf8'), 'got response')
     )
 })
 
@@ -205,7 +205,7 @@ t.test('gzip + stream body param', t => {
     .post('/hello')
     .reply(200, (uri, reqBody) => {
       reqBody = zlib.gunzipSync(Buffer.from(reqBody, 'hex'))
-      t.deepEqual(JSON.parse(reqBody.toString('utf8')), {
+      t.same(JSON.parse(reqBody.toString('utf8')), {
         hello: 'world',
       }, 'got the stringified version of the body')
       return reqBody
@@ -227,7 +227,7 @@ t.test('gzip + stream body param', t => {
       t.equal(res.status, 200)
       return res.json()
     })
-    .then(json => t.deepEqual(json, { hello: 'world' }))
+    .then(json => t.same(json, { hello: 'world' }))
 })
 
 t.test('query strings', t => {
@@ -255,7 +255,7 @@ t.test('json()', t => {
     .get('/hello')
     .reply(200, { hello: 'world' })
   return fetch.json('/hello', OPTS)
-    .then(json => t.deepEqual(json, { hello: 'world' }, 'got json body'))
+    .then(json => t.same(json, { hello: 'world' }, 'got json body'))
 })
 
 t.test('query string with ?write=true', t => {
@@ -289,7 +289,7 @@ t.test('fetch.json.stream()', t => {
     c: 3,
   })
   return fetch.json.stream('/hello', '$*', OPTS).collect().then(data => {
-    t.deepEqual(data, [
+    t.same(data, [
       { key: 'a', value: 1 },
       { key: 'b', value: 2 },
       { key: 'c', value: 3 },
@@ -309,7 +309,7 @@ t.test('fetch.json.stream opts.mapJSON', t => {
       return [key, value]
     },
   }).collect().then(data => {
-    t.deepEqual(data, [
+    t.same(data, [
       ['a', 1],
       ['b', 2],
       ['c', 3],
@@ -430,7 +430,7 @@ t.test('pickRegistry() utility', t => {
     'https://my.scoped.registry/here/',
     'scope @ is option@l'
   )
-  t.done()
+  t.end()
 })
 
 t.test('pickRegistry through opts.spec', t => {


### PR DESCRIPTION
This refactors the handling of auth in the new context where npm/cli
will _only_ ever send authorization in such a way that any
authorization-related options are scoped to a given sanitized registry
host and path.

This fixes a troubling situation where a user has intentionally logged
into two separate registries, one which serves package distribution
tarballs, and the other which has packuments pointing to it.

For example, a request to `https://registry.internal/private-thing`
might return this packument:

```json
{
  "name": "private-thing",
  "dist-tags": {
    "latest": "1.0.0"
  },
  "versions": {
    "1.0.0": {
      "name": "private-thing",
      "version": "1.0.0",
      "dist": {
        "tarball": "https://tarballs.internal/private-thing-1.0.0.tgz"
      }
    }
  }
}
```

If the user has properly logged into both `https://registry.internal`
and `https://tarballs.internal` (or at least placed an auth or bearer
token in their `.npmrc` for each), then this should work properly when
they run:

```
npm install private-thing --registry=https://registry.internal
```

However, previously the auth for `https://tarballs.internal` would never
be loaded, because it was being loaded based solely on the _registry_
URI, regardless of the actual URI being fetched, and then only _sent_
when the hostname matches, and so the request for the tarball would
fail.

BREAKING CHANGES:

* The `alwaysAuth` config is no longer relevant.  If we have
  authentication information for a given URI, we send it when making the
  request to that URI.  This was previously being done based on the
  presence of a `scope` parameter or a scoped `spec` option.  However,
  that is not reliable, as users can depend directly on tarball URLs,
  and other parts of the system may have reason to make requests to the
  registry in question without a specific dependency spec in mind (for
  example, to fetch a packument for the purpose of calculating
  metavulnerabilities during an `npm audit` operation.)

* A top level `_auth`, `_authToken`, `username`, `_password`, or
  `password` option is no longer respected if not scoped to a given
  registry URL.  This functionality was removed from npm/cli as of
  version 7, due to the risk of sending credentials to an incorrect host
  by mistake.  The npm cli will automatically scope these top-level
  configs to the default registry option and save them back to the
  `.npmrc` file the first time they are encountered, so users generally
  see no disruption, and this change only affects non-npm users of
  npm-registry-fetch.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
