### PR TITLE
fix(auth): support legacy global _auth

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -71,6 +71,14 @@ const getAuth = (uri, opts = {}) => {
       // and warn the user if we get a 4xx error on it.
       const scopeAuthKey = regKeyFromURI(registry, opts)
       return new Auth({ scopeAuthKey })
+    } else {
+      return new Auth({
+        scopeAuthKey: null,
+        token: opts._authToken,
+        auth: opts._auth,
+        username: opts.username,
+        password: opts._password,
+      })
     }
   }
 

--- a/test/auth.js
+++ b/test/auth.js
@@ -113,6 +113,27 @@ t.test('forceAuth', t => {
     .then(res => t.equal(res, 'success', 'used forced auth details'))
 })
 
+t.test('_auth legacy global', t => {
+  const config = {
+    registry: 'https://my.custom.registry/here/',
+    _auth: 'deadbeef',
+  }
+  t.same(getAuth(`${config.registry}/asdf/foo/bar/baz`, config), {
+    scopeAuthKey: null,
+    token: null,
+    isBasicAuth: false,
+    auth: 'deadbeef',
+  }, 'correct legacy global _auth picked out')
+
+  const opts = Object.assign({}, OPTS, config)
+  tnock(t, opts.registry)
+    .matchHeader('authorization', 'Basic deadbeef')
+    .get('/hello')
+    .reply(200, '"success"')
+  return fetch.json('/hello', opts)
+    .then(res => t.equal(res, 'success', '_auth auth succeeded'))
+})
+
 t.test('_auth auth', t => {
   const config = {
     registry: 'https://my.custom.registry/here/',


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR adds support for a global `_auth` field in a user's `.npmrc`.  This was supported prior to version 10 of this library.

## References
Related to https://github.com/npm/npm-registry-fetch/issues/47
