### PR TITLE
BREAKING CHANGE: remove handling of deprecated warning headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "10.1.1",
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^6.0.0",
         "make-fetch-happen": "^8.0.9",
         "minipass": "^3.1.3",
         "minipass-fetch": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "lru-cache": "^6.0.0",
     "make-fetch-happen": "^8.0.9",
     "minipass": "^3.1.3",
     "minipass-fetch": "^1.3.0",

--- a/test/check-response.js
+++ b/test/check-response.js
@@ -135,30 +135,6 @@ t.test('redact password from log', t => {
   res.body.emit('end')
 })
 
-t.test('bad-formatted warning headers', t => {
-  const headers = new Headers()
-  headers.has = header => header === 'warning' ? 'foo' : undefined
-  headers.raw = () => ({
-    warning: ['100 - foo'],
-  })
-  const res = Object.assign({}, mockFetchRes, {
-    headers,
-  })
-  return t.resolves(checkResponse({
-    method: 'get',
-    res,
-    registry,
-    startTime,
-    opts: {
-      log: Object.assign({}, silentLog, {
-        warn (header, msg) {
-          t.fail('should not log warnings')
-        },
-      }),
-    },
-  }))
-})
-
 t.test('report auth for registry, but not for this request', t => {
   const res = Object.assign({}, mockFetchRes, {
     buffer: () => Promise.resolve(Buffer.from('ok')),

--- a/test/index.js
+++ b/test/index.js
@@ -466,24 +466,6 @@ t.test('pickRegistry through opts.spec', t => {
   ))
 })
 
-t.test('log warning header info', t => {
-  tnock(t, defaultOpts.registry)
-    .get('/hello')
-    .reply(200, { hello: 'world' }, { Warning: '199 - "ENOTFOUND" "Wed, 21 Oct 2015 07:28:00 GMT"' })
-  const opts = {
-    ...OPTS,
-    log: Object.assign({}, silentLog, {
-      warn (header, msg) {
-        t.equal(header, 'registry', 'expected warn log header')
-        t.equal(msg, `Using stale data from ${defaultOpts.registry} because the host is inaccessible -- are you offline?`, 'logged out at WARNING level')
-      },
-    }),
-  }
-  t.plan(3)
-  return fetch('/hello', opts)
-    .then(res => t.equal(res.status, 200, 'got successful response'))
-})
-
 t.test('miscellaneous headers', t => {
   tnock(t, defaultOpts.registry)
     .matchHeader('npm-session', session =>


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The `Warning` header has been deprecated, so let's not deal with it any more.

This will be necessary when we update make-fetch-happen after npm/make-fetch-happen#49 lands

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to npm/make-fetch-happen#49