### PR TITLE
chore: change deprecated cacheManager to cachePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
       algorithms: opts.algorithms,
       body,
       cache: getCacheMode(opts),
-      cacheManager: opts.cache,
+      cachePath: opts.cache,
       ca: opts.ca,
       cert: opts.cert,
       headers,


### PR DESCRIPTION
`cacheManager` is deprecated in favor of `cachePath`. `cacheManager` is not documented so I was confused how npm-fetch-registry was caching without setting `cachePath`.

Searching for `cacheManager` in make-fetch-happen explains it:
https://github.com/npm/make-fetch-happen/blob/4d7b9c7e9f243258bff8329eba0beae448304af8/lib/options.js#L36-L42

This update should be safe because m-f-h is already copying the option to cachePath.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
