### PR TITLE
feat(opts): use scope instead of projectScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ This option is generally only useful if you're also using
 This option is set to `true` when the request includes `write=true` in the
 query string.
 
-##### <a name="opts-projectScope"></a> `opts.projectScope`
+##### <a name="opts-scope"></a> `opts.scope`
 
 * Type: String
 * Default: null

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,8 +213,8 @@ function getHeaders (uri, auth, opts) {
     'user-agent': opts.userAgent,
   }, opts.headers || {})
 
-  if (opts.projectScope) {
-    headers['npm-scope'] = opts.projectScope
+  if (opts.scope) {
+    headers['npm-scope'] = opts.scope
   }
 
   if (opts.npmSession) {

--- a/test/index.js
+++ b/test/index.js
@@ -483,7 +483,7 @@ t.test('miscellaneous headers', t => {
     ...OPTS,
     registry: null, // always falls back on falsey registry value
     npmSession: 'foobarbaz',
-    projectScope: '@foo',
+    scope: '@foo',
     userAgent: 'agent of use',
     npmCommand: 'hello-world',
   }).then(res => {


### PR DESCRIPTION
BREAKING CHANGE: this changes the name of an opts attribute from
`projectScope` to `scope`
