### PR TITLE
fix: consistent use of url.URL

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,5 +1,6 @@
 'use strict'
 const npa = require('npm-package-arg')
+const { URL } = require('url')
 
 // Find the longest registry key that is used for some kind of auth
 // in the options.


### PR DESCRIPTION
Even though the engines field limits the range of node versions to those
that have a global URL, all but one of the files still used
require('url').URL.  This fixes the one remaining file to also use that.
While older versions of node are still not supported, and not
recommended, this will allow this module to potentially still work there
for the time being.
