### PR TITLE
feat: use proc-log and drop npmlog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,14 +337,6 @@ to the registry.
 
 See also [`opts.proxy`](#opts-proxy)
 
-##### <a name="opts-log"></a> `opts.log`
-
-* Type: [`npmlog`](https://npm.im/npmlog)-like
-* Default: null
-
-Logger object to use for logging operation details. Must have the same methods
-as `npmlog`.
-
 ##### <a name="opts-mapJSON"></a> `opts.mapJSON`
 
 * Type: Function

--- a/lib/check-response.js
+++ b/lib/check-response.js
@@ -3,23 +3,24 @@
 const errors = require('./errors.js')
 const { Response } = require('minipass-fetch')
 const defaultOpts = require('./default-opts.js')
+const log = require('proc-log')
 
 /* eslint-disable-next-line max-len */
 const moreInfoUrl = 'https://github.com/npm/cli/wiki/No-auth-for-URI,-but-auth-present-for-scoped-registry'
 const checkResponse =
-  async ({ method, uri, res, registry, startTime, auth, opts }) => {
+  async ({ method, uri, res, startTime, auth, opts }) => {
     opts = { ...defaultOpts, ...opts }
     if (res.headers.has('npm-notice') && !res.headers.has('x-local-cache')) {
-      opts.log.notice('', res.headers.get('npm-notice'))
+      log.notice('', res.headers.get('npm-notice'))
     }
 
     if (res.status >= 400) {
-      logRequest(method, res, startTime, opts)
+      logRequest(method, res, startTime)
       if (auth && auth.scopeAuthKey && !auth.token && !auth.auth) {
       // we didn't have auth for THIS request, but we do have auth for
       // requests to the registry indicated by the spec's scope value.
       // Warn the user.
-        opts.log.warn('registry', `No auth for URI, but auth present for scoped registry.
+        log.warn('registry', `No auth for URI, but auth present for scoped registry.
 
 URI: ${uri}
 Scoped Registry Key: ${auth.scopeAuthKey}
@@ -38,7 +39,7 @@ More info here: ${moreInfoUrl}`)
   }
 module.exports = checkResponse
 
-function logRequest (method, res, startTime, opts) {
+function logRequest (method, res, startTime) {
   const elapsedTime = Date.now() - startTime
   const attempt = res.headers.get('x-fetch-attempts')
   const attemptStr = attempt && attempt > 1 ? ` attempt #${attempt}` : ''
@@ -58,7 +59,7 @@ function logRequest (method, res, startTime, opts) {
     urlStr = res.url
   }
 
-  opts.log.http(
+  log.http(
     'fetch',
     `${method.toUpperCase()} ${res.status} ${urlStr} ${elapsedTime}ms${attemptStr}${cacheStr}`
   )

--- a/lib/default-opts.js
+++ b/lib/default-opts.js
@@ -1,6 +1,5 @@
 const pkg = require('../package.json')
 module.exports = {
-  log: require('./silentlog.js'),
   maxSockets: 12,
   method: 'GET',
   registry: 'https://registry.npmjs.org/',

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "minipass-fetch": "^1.4.1",
     "minipass-json-stream": "^1.0.1",
     "minizlib": "^2.1.2",
-    "npm-package-arg": "^9.0.0"
+    "npm-package-arg": "^9.0.0",
+    "proc-log": "^2.0.0"
   },
   "devDependencies": {
     "@npmcli/template-oss": "^2.7.1",
     "cacache": "^15.3.0",
     "nock": "^13.2.4",
-    "npmlog": "^6.0.1",
     "require-inject": "^1.4.4",
     "ssri": "^8.0.1",
     "tap": "^15.1.6"

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,15 +1,12 @@
 'use strict'
 
-const npmlog = require('npmlog')
 const t = require('tap')
 const tnock = require('./util/tnock.js')
 
 const fetch = require('..')
 const getAuth = require('../lib/auth.js')
 
-npmlog.level = process.env.LOGLEVEL || 'silent'
 const OPTS = {
-  log: npmlog,
   timeout: 0,
   retry: {
     retries: 1,

--- a/test/cache.js
+++ b/test/cache.js
@@ -2,7 +2,6 @@
 
 const { promisify } = require('util')
 const statAsync = promisify(require('fs').stat)
-const npmlog = require('npmlog')
 const path = require('path')
 const t = require('tap')
 const tnock = require('./util/tnock.js')
@@ -11,10 +10,8 @@ const fetch = require('..')
 
 const testDir = t.testdir({})
 
-npmlog.level = process.env.LOGLEVEL || 'silent'
 const REGISTRY = 'https://mock.reg'
 const OPTS = {
-  log: npmlog,
   memoize: false,
   timeout: 0,
   retry: {

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,16 +1,13 @@
 'use strict'
 
 const npa = require('npm-package-arg')
-const npmlog = require('npmlog')
 const t = require('tap')
 const tnock = require('./util/tnock.js')
 const errors = require('../lib/errors.js')
 
 const fetch = require('..')
 
-npmlog.level = process.env.LOGLEVEL || 'silent'
 const OPTS = {
-  log: npmlog,
   timeout: 0,
   retry: {
     retries: 1,


### PR DESCRIPTION
BREAKING CHANGE: this drops support for passing in a `log` property. All
logs are now emitted on the process object via `proc-log`
