### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,7 +4,7 @@ const url = require('url')
 
 function packageName (href) {
   try {
-    let basePath = new url.URL(href).pathname.substr(1)
+    let basePath = new url.URL(href).pathname.slice(1)
     if (!basePath.match(/^-/)) {
       basePath = basePath.split('/')
       var index = basePath.indexOf('_rewrite')


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.