### PR TITLE
Decode npm-notice heder according to the rfc2047 rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### ⚠ BREAKING CHANGES
+
+* Decode `npm-notice` heder according to the rfc2047 rule. 
+
+### Dependencies
+* add rfc2047
+
 ### [13.1.1](https://github.com/npm/npm-registry-fetch/compare/v13.1.0...v13.1.1) (2022-04-13)
 
 

--- a/lib/check-response.js
+++ b/lib/check-response.js
@@ -5,6 +5,7 @@ const { Response } = require('minipass-fetch')
 const defaultOpts = require('./default-opts.js')
 const log = require('proc-log')
 const cleanUrl = require('./clean-url.js')
+const rfc2047 = require('rfc2047')
 
 /* eslint-disable-next-line max-len */
 const moreInfoUrl = 'https://github.com/npm/cli/wiki/No-auth-for-URI,-but-auth-present-for-scoped-registry'
@@ -12,7 +13,12 @@ const checkResponse =
   async ({ method, uri, res, startTime, auth, opts }) => {
     opts = { ...defaultOpts, ...opts }
     if (res.headers.has('npm-notice') && !res.headers.has('x-local-cache')) {
-      log.notice('', res.headers.get('npm-notice'))
+      let notice = res.headers.get('npm-notice')
+      try {
+        notice = rfc2047.decode(notice)
+      } catch {
+      }
+      log.notice('', notice)
     }
 
     if (res.status >= 400) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "minipass-json-stream": "^1.0.1",
     "minizlib": "^2.1.2",
     "npm-package-arg": "^9.0.1",
-    "proc-log": "^2.0.0"
+    "proc-log": "^2.0.0",
+    "rfc2047": "^4.0.1"
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^3.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -366,6 +366,27 @@ t.test('npm-notice header logging', async t => {
   t.equal(msg, 'npm <3 u', 'logged out npm-notice at NOTICE level')
 })
 
+t.test('npm-notice encoded header logging', async t => {
+  tnock(t, defaultOpts.registry)
+    .get('/hello')
+    .reply(200, { hello: 'world' }, {
+      'npm-notice': 'npm=?utf-8?Q?_=E2=98=BA?=',
+    })
+
+  let header, msg
+  process.on('log', (level, ...args) => {
+    if (level === 'notice') {
+      ;[header, msg] = args
+    }
+  })
+
+  t.plan(3)
+  const res = await fetch('/hello', { ...OPTS })
+  t.equal(res.status, 200, 'got successful response')
+  t.equal(header, '', 'empty log header thing')
+  t.equal(msg, 'npm ☺', 'logged out npm-notice at NOTICE level')
+})
+
 t.test('optionally verifies request body integrity', t => {
   t.plan(3)
   tnock(t, defaultOpts.registry)


### PR DESCRIPTION
Currently server can send only 7-bit ASCII data in `npm-notice` header.

This code change will allow to send any Unicode message. The rfc2047 encoding it is used in similar place (Subject header) in electronic mail. Plain messages that do not contain a very specific phrase `=?[...]?=` will not be modified.

## References
  Fixes #37
