### PR TITLE
feat: set 'npm-auth-type' header depending on config option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,7 +213,9 @@ function getHeaders (uri, auth, opts) {
     'user-agent': opts.userAgent,
   }, opts.headers || {})
 
-  headers['npm-use-webauthn'] = opts.authType === 'webauthn'
+  if (opts.authType) {
+    headers['npm-auth-type'] = opts.authType
+  }
 
   if (opts.scope) {
     headers['npm-scope'] = opts.scope

--- a/lib/index.js
+++ b/lib/index.js
@@ -213,6 +213,8 @@ function getHeaders (uri, auth, opts) {
     'user-agent': opts.userAgent,
   }, opts.headers || {})
 
+  headers['npm-use-webauthn'] = opts.authType === 'webauthn'
+
   if (opts.scope) {
     headers['npm-scope'] = opts.scope
   }

--- a/test/index.js
+++ b/test/index.js
@@ -473,6 +473,8 @@ t.test('miscellaneous headers', t => {
       t.strictSame(ua, ['agent of use'], 'UA set from options'))
     .matchHeader('npm-command', cmd =>
       t.strictSame(cmd, ['hello-world'], 'command set from options'))
+    .matchHeader('npm-use-webauthn', useWebauthn =>
+      t.strictSame(useWebauthn, ['true'], 'use-webauthn set from options'))
     .get('/hello')
     .reply(200, { hello: 'world' })
 
@@ -483,6 +485,7 @@ t.test('miscellaneous headers', t => {
     scope: '@foo',
     userAgent: 'agent of use',
     npmCommand: 'hello-world',
+    authType: 'webauthn',
   }).then(res => {
     t.equal(res.status, 200, 'got successful response')
   })

--- a/test/index.js
+++ b/test/index.js
@@ -473,8 +473,8 @@ t.test('miscellaneous headers', t => {
       t.strictSame(ua, ['agent of use'], 'UA set from options'))
     .matchHeader('npm-command', cmd =>
       t.strictSame(cmd, ['hello-world'], 'command set from options'))
-    .matchHeader('npm-use-webauthn', useWebauthn =>
-      t.strictSame(useWebauthn, ['true'], 'use-webauthn set from options'))
+    .matchHeader('npm-auth-type', authType =>
+      t.strictSame(authType, ['auth'], 'auth-type set from options'))
     .get('/hello')
     .reply(200, { hello: 'world' })
 
@@ -485,7 +485,22 @@ t.test('miscellaneous headers', t => {
     scope: '@foo',
     userAgent: 'agent of use',
     npmCommand: 'hello-world',
-    authType: 'webauthn',
+    authType: 'auth',
+  }).then(res => {
+    t.equal(res.status, 200, 'got successful response')
+  })
+})
+
+t.test('miscellaneous headers not being set if not present in options', t => {
+  tnock(t, defaultOpts.registry)
+    .matchHeader('npm-auth-type', authType =>
+      t.strictSame(authType, undefined, 'auth-type not set from options'))
+    .get('/hello')
+    .reply(200, { hello: 'world' })
+
+  return fetch('/hello', {
+    ...OPTS,
+    authType: undefined,
   }).then(res => {
     t.equal(res.status, 200, 'got successful response')
   })


### PR DESCRIPTION
## What
Set the `npm-auth-type` header to the value of the `--auth-type` command line parameter.

## Why
Allows the registry to know if the `npm` client is capable of handling new web based flows for commands that require extra verification steps.

## References
- Closes https://github.com/github/npm/issues/5465
- https://github.com/github/npm/issues/5361
- https://github.com/github/npm/issues/5218
