### PR TITLE
fix: use accept-encoding instead of content-encoding for requests favoring gzip

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
   }
 
   if (opts.gzip) {
-    headers['content-encoding'] = 'gzip'
+    headers['accept-encoding'] = 'gzip'
     if (bodyIsStream) {
       const gz = new zlib.Gzip()
       body.on('error', /* istanbul ignore next: unlikely and hard to test */


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding , a request accepting gzip response ususally uses `Accept-Encoding` header, not `Content-Encoding` (which is used by the response).

Such request with invalid request header is forbidden by some mirrror sites:

```
$ curl -L --http1.1 -H 'content-encoding: gzip' -H 'content-type: application/json' -i 'https://registry.npmmirror.com/tar/-/tar-6.2.1.tgz'
HTTP/1.1 400 Bad Request
Server: Tengine
Content-Type: text/html; charset=utf-8
Content-Length: 24
Connection: keep-alive
Strict-Transport-Security: max-age=5184000
Date: *
Vary: Origin
Via: *
Ali-Swift-Global-Savetime: *
X-Cache: MISS TCP_MISS dirn:-2:-2
X-Swift-Error: orig response 4XX error
X-Swift-SaveTime: *
X-Swift-CacheTime: 0
Timing-Allow-Origin: *
EagleId: *

<h2>400 Bad Request</h2>
```

The original code of commit 340abe07c952b387978f6a55cfd0071f6be3464e is likely a typo.


