### PR TITLE
fix: log cache hits distinct from fetch

### DIFF
--- a/lib/check-response.js
+++ b/lib/check-response.js
@@ -48,10 +48,18 @@ function logRequest (method, res, startTime) {
   const cacheStr = cacheStatus ? ` (cache ${cacheStatus})` : ''
   const urlStr = cleanUrl(res.url)
 
-  log.http(
-    'fetch',
-    `${method.toUpperCase()} ${res.status} ${urlStr} ${elapsedTime}ms${attemptStr}${cacheStr}`
-  )
+  // If make-fetch-happen reports a cache hit, then there was no fetch
+  if (cacheStatus === 'hit') {
+    log.http(
+      'cache',
+      `${urlStr} ${elapsedTime}ms${attemptStr}${cacheStr}`
+    )
+  } else {
+    log.http(
+      'fetch',
+      `${method.toUpperCase()} ${res.status} ${urlStr} ${elapsedTime}ms${attemptStr}${cacheStr}`
+    )
+  }
 }
 
 function checkErrors (method, res, startTime, opts) {

--- a/test/check-response.js
+++ b/test/check-response.js
@@ -224,9 +224,9 @@ t.test('logs the value of x-local-cache-status when set', t => {
     startTime,
   })
   res.body.emit('end')
-  t.equal(header, 'fetch')
+  t.equal(header, 'cache')
   t.match(
     msg,
-    /^GET 200 http:\/\/username:\*\*\*@example.com\/foo\/bar\/baz [0-9]+m?s \(cache hit\)$/
+    /^http:\/\/username:\*\*\*@example.com\/foo\/bar\/baz [0-9]+m?s \(cache hit\)$/
   )
 })


### PR DESCRIPTION
Avoid confusion between actual remote fetches and cache hits (which don't involve a fetch).

Ref https://github.com/npm/pacote/pull/403#issuecomment-2405433421